### PR TITLE
[STUDIO-7375] Add WebUI Chrome settings to Disable password leak detection feature on Chrome

### DIFF
--- a/settings/internal/com.kms.katalon.core.webui.chrome.properties
+++ b/settings/internal/com.kms.katalon.core.webui.chrome.properties
@@ -1,1 +1,1 @@
-{"CHROME_DRIVER":{}}
+{"CHROME_DRIVER":{"prefs":{"profile.password_manager_leak_detection":false}}}


### PR DESCRIPTION
### Description

- Add project WebUI Chrome settings `"prefs":{"profile.password_manager_leak_detection":false}` to disable password security popup for web test project

### References

[STUDIO-7375](https://katalon.atlassian.net/browse/STUDIO-7375)